### PR TITLE
Fix weekly habit streaks and improve navigation layout

### DIFF
--- a/dev-dist/sw.js
+++ b/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-ce4f0d5f'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.blso4do5it8"
+    "revision": "0.o42d364u26"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2519,6 +2519,23 @@ function App() {
                             </div>
                             <div className="text-xl sm:text-2xl font-bold bg-gradient-to-r from-violet-600 via-purple-600 to-indigo-600 bg-clip-text text-transparent drop-shadow-sm">TimePilot</div>
                         </div>
+                        <div className="hidden lg:flex flex-1 items-center justify-center">
+                            <div className="flex items-center bg-gradient-to-r from-blue-100/80 via-indigo-100/80 to-purple-100/80 dark:from-gray-800/80 dark:via-blue-900/40 dark:to-indigo-900/40 rounded-2xl p-1.5 shadow-inner border border-blue-200/50 dark:border-blue-800/50">
+                                {tabs.map((tab) => (
+                                    <button
+                                        key={tab.id}
+                                        onClick={() => { setActiveTab(tab.id as typeof activeTab); setMobileMenuOpen(false); }}
+                                        className={`flex items-center justify-center px-5 py-2.5 rounded-xl text-sm font-semibold transition-all duration-300 relative group ${activeTab === tab.id ? 'bg-gradient-to-r from-blue-500 via-indigo-500 to-purple-500 text-white shadow-lg shadow-blue-500/30' : 'text-gray-700 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-white/80 dark:hover:bg-gray-700/60'} ${showInteractiveTutorial && highlightedTab === tab.id ? 'ring-2 ring-yellow-400 animate-pulse' : ''}`}
+                                        title={tab.label}
+                                    >
+                                        <tab.icon size={18} className={activeTab === tab.id ? 'drop-shadow-sm' : 'group-hover:scale-110 transition-transform'} />
+                                        {activeTab === tab.id && (
+                                            <span className="ml-2.5 hidden xl:inline drop-shadow-sm">{tab.label}</span>
+                                        )}
+                                    </button>
+                                ))}
+                            </div>
+                        </div>
                         <div className="flex items-center space-x-2 sm:space-x-3 md:space-x-4">
                             <button
                                 className={`flex items-center rounded-xl sm:rounded-2xl p-2 sm:p-3 backdrop-blur-lg transition-all duration-300 z-50 border-2 ${
@@ -2581,7 +2598,7 @@ function App() {
                 <nav className="sticky-nav backdrop-blur-xl bg-gradient-to-r from-white/90 via-blue-50/85 to-indigo-50/85 dark:from-gray-900/95 dark:via-blue-900/25 dark:to-indigo-900/25 shadow-2xl shadow-blue-500/8 dark:shadow-blue-900/15 border-b border-gradient-to-r from-blue-200/15 via-indigo-200/15 to-purple-200/15 dark:from-blue-800/15 dark:via-indigo-800/15 dark:to-purple-800/15">
                     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                         {/* Desktop Navigation */}
-                        <div className="hidden lg:flex items-center justify-start space-x-1 py-2">
+                        <div className="hidden">
                             <div className="flex items-center bg-gradient-to-r from-blue-100/80 via-indigo-100/80 to-purple-100/80 dark:from-gray-800/80 dark:via-blue-900/40 dark:to-indigo-900/40 rounded-2xl p-1 shadow-inner border border-blue-200/50 dark:border-blue-800/50">
                                 {tabs.map((tab) => (
                                     <button

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2581,8 +2581,8 @@ function App() {
                 <nav className="sticky-nav backdrop-blur-xl bg-gradient-to-r from-white/90 via-blue-50/85 to-indigo-50/85 dark:from-gray-900/95 dark:via-blue-900/25 dark:to-indigo-900/25 shadow-2xl shadow-blue-500/8 dark:shadow-blue-900/15 border-b border-gradient-to-r from-blue-200/15 via-indigo-200/15 to-purple-200/15 dark:from-blue-800/15 dark:via-indigo-800/15 dark:to-purple-800/15">
                     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                         {/* Desktop Navigation */}
-                        <div className="hidden lg:flex items-center justify-center space-x-1 py-4">
-                            <div className="flex items-center bg-gradient-to-r from-blue-100/80 via-indigo-100/80 to-purple-100/80 dark:from-gray-800/80 dark:via-blue-900/40 dark:to-indigo-900/40 rounded-2xl p-1.5 shadow-inner border border-blue-200/50 dark:border-blue-800/50">
+                        <div className="hidden lg:flex items-center justify-start space-x-1 py-2">
+                            <div className="flex items-center bg-gradient-to-r from-blue-100/80 via-indigo-100/80 to-purple-100/80 dark:from-gray-800/80 dark:via-blue-900/40 dark:to-indigo-900/40 rounded-2xl p-1 shadow-inner border border-blue-200/50 dark:border-blue-800/50">
                                 {tabs.map((tab) => (
                                     <button
                                         key={tab.id}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2530,7 +2530,7 @@ function App() {
                                     >
                                         <tab.icon size={18} className={activeTab === tab.id ? 'drop-shadow-sm' : 'group-hover:scale-110 transition-transform'} />
                                         {activeTab === tab.id && (
-                                            <span className="ml-2.5 hidden xl:inline drop-shadow-sm">{tab.label}</span>
+                                            <span className="ml-2.5 inline drop-shadow-sm">{tab.label}</span>
                                         )}
                                     </button>
                                 ))}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -335,6 +335,9 @@ const Dashboard: React.FC<DashboardProps> = ({ tasks, studyPlans, dailyAvailable
         );
       }, [Math.floor((tasks.length > 0 ? (completedTasks.length / tasks.length) * 100 : 0) / 10), completedTasks.length])}
 
+      {/* Habits Card - placed under motivational quotes */}
+      <HabitTracker habits={habits} onAddHabit={onAddHabit} onToggleHabitToday={onToggleHabitToday} onDeleteHabit={onDeleteHabit} />
+
       {/* Progress Overview and Today's Sessions - Side by Side */}
       <div className="flex flex-col lg:flex-row gap-6 mb-6">
         {/* Progress Overview - Left Side */}
@@ -836,8 +839,6 @@ const Dashboard: React.FC<DashboardProps> = ({ tasks, studyPlans, dailyAvailable
       </div>
 
       {/* Move session analytics, recent activities, and table into a compact grid at the bottom */}
-      {/* Habits Card */}
-      <HabitTracker habits={habits} onAddHabit={onAddHabit} onToggleHabitToday={onToggleHabitToday} onDeleteHabit={onDeleteHabit} />
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
         {/* Session Analytics Card - Bottom */}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -232,9 +232,7 @@ const Dashboard: React.FC<DashboardProps> = ({ tasks, studyPlans, dailyAvailable
         </div>
       </div>
 
-      <EnvironmentCard />
-
-          {useMemo(() => {
+           {useMemo(() => {
         const totalAllEstimatedHours = tasks.reduce((sum, task) => sum + task.estimatedHours, 0);
         
         const taskCompletionRate = tasks.length > 0 ? Math.round((completedTasks.length / tasks.length) * 100) : 0;
@@ -337,6 +335,9 @@ const Dashboard: React.FC<DashboardProps> = ({ tasks, studyPlans, dailyAvailable
 
       {/* Habits Card - placed under motivational quotes */}
       <HabitTracker habits={habits} onAddHabit={onAddHabit} onToggleHabitToday={onToggleHabitToday} onDeleteHabit={onDeleteHabit} />
+
+      {/* Your Environment - moved below Habits */}
+      <EnvironmentCard />
 
       {/* Progress Overview and Today's Sessions - Side by Side */}
       <div className="flex flex-col lg:flex-row gap-6 mb-6">

--- a/src/components/HabitTracker.tsx
+++ b/src/components/HabitTracker.tsx
@@ -27,21 +27,27 @@ const computeWeeklyStreak = (history: string[], targetPerWeek: number = 1, today
     const key = startOfWeek.toISOString().split('T')[0];
     byWeek.set(key, (byWeek.get(key) || 0) + 1);
   });
-  let streak = 0;
   const now = new Date(todayStr);
-  const weekStart = new Date(now);
-  weekStart.setDate(now.getDate() - now.getDay());
+  const currentWeekStart = new Date(now);
+  currentWeekStart.setDate(now.getDate() - now.getDay());
+  const currentWeekKey = currentWeekStart.toISOString().split('T')[0];
+  const currentWeekCount = byWeek.get(currentWeekKey) || 0;
+
+  let prevStreak = 0;
+  const weekIter = new Date(currentWeekStart);
+  weekIter.setDate(weekIter.getDate() - 7);
   while (true) {
-    const key = weekStart.toISOString().split('T')[0];
+    const key = weekIter.toISOString().split('T')[0];
     const count = byWeek.get(key) || 0;
     if (count >= targetPerWeek) {
-      streak += 1;
-      weekStart.setDate(weekStart.getDate() - 7);
+      prevStreak += 1;
+      weekIter.setDate(weekIter.getDate() - 7);
     } else {
       break;
     }
   }
-  return streak;
+
+  return currentWeekCount >= targetPerWeek ? prevStreak + 1 : prevStreak;
 };
 
 interface HabitTrackerProps {

--- a/src/components/HabitTracker.tsx
+++ b/src/components/HabitTracker.tsx
@@ -3,6 +3,47 @@ import { useMemo, useState } from 'react';
 import { Habit } from '../types';
 import { getLocalDateString } from '../utils/scheduling';
 
+const computeDailyStreak = (dates: Set<string>, todayStr: string) => {
+  let streak = 0;
+  const d = new Date(todayStr);
+  while (true) {
+    const yyyy = d.toISOString().split('T')[0];
+    if (dates.has(yyyy)) {
+      streak += 1;
+      d.setDate(d.getDate() - 1);
+    } else {
+      break;
+    }
+  }
+  return streak;
+};
+
+const computeWeeklyStreak = (history: string[], targetPerWeek: number = 1, todayStr: string) => {
+  const byWeek = new Map<string, number>();
+  history.forEach(d => {
+    const date = new Date(d);
+    const startOfWeek = new Date(date);
+    startOfWeek.setDate(date.getDate() - date.getDay());
+    const key = startOfWeek.toISOString().split('T')[0];
+    byWeek.set(key, (byWeek.get(key) || 0) + 1);
+  });
+  let streak = 0;
+  const now = new Date(todayStr);
+  const weekStart = new Date(now);
+  weekStart.setDate(now.getDate() - now.getDay());
+  while (true) {
+    const key = weekStart.toISOString().split('T')[0];
+    const count = byWeek.get(key) || 0;
+    if (count >= targetPerWeek) {
+      streak += 1;
+      weekStart.setDate(weekStart.getDate() - 7);
+    } else {
+      break;
+    }
+  }
+  return streak;
+};
+
 interface HabitTrackerProps {
   habits: Habit[];
   onAddHabit: (habit: { title: string; cadence: 'daily' | 'weekly'; targetPerWeek?: number; reminder?: boolean }) => void;
@@ -136,7 +177,7 @@ export default function HabitTracker({ habits, onAddHabit, onToggleHabitToday, o
                         </span>
                       )}
                       <span className="text-[11px] px-2 py-0.5 rounded-full bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200 inline-flex items-center gap-1">
-                        <Flame className="w-3 h-3" /> Streak: {habit.streak}
+                        <Flame className="w-3 h-3" /> Streak: {habit.cadence === 'daily' ? computeDailyStreak(new Set(habit.history), today) : computeWeeklyStreak(habit.history, habit.targetPerWeek || 1, today)}
                       </span>
                     </div>
 


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses several UI/UX improvements:
- Weekly habit streaks should only reset per week, not mid-week
- Navigation tabs should be repositioned for better space efficiency in desktop view
- Tab names should appear when the tab is active
- Environment section should be moved below the habits section for better content organization

## Code changes

**Habit streak calculation:**
- Fixed weekly streak logic to only count complete weeks and not reset mid-week
- Moved streak computation functions to HabitTracker component for better organization
- Updated streak display to use the corrected calculation methods

**Navigation improvements:**
- Moved navigation tabs to header row, aligned with logo for space efficiency
- Added conditional display of tab labels when active
- Hidden the old navigation section while keeping the new header-integrated version

**Dashboard layout:**
- Repositioned HabitTracker component above EnvironmentCard
- Moved environment section below habits section as requested

**Service worker:**
- Updated revision hash for deploymentTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/117bf1b63f164278b2dd01974f1b43bc/mystic-landing)

👀 [Preview Link](https://117bf1b63f164278b2dd01974f1b43bc-mystic-landing.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>117bf1b63f164278b2dd01974f1b43bc</projectId>-->
<!--<branchName>mystic-landing</branchName>-->